### PR TITLE
Revert "e610: enable moving apps to sd"

### DIFF
--- a/fstab.m4
+++ b/fstab.m4
@@ -17,7 +17,7 @@
 /dev/block/platform/msm_sdcc.3/by-num/p16         /cache       ext4    nosuid,nodev,barrier=1                       wait,check
 
 # External SD
-/devices/platform/msm_sdcc.1/mmc_host/mmc1       auto vfat defaults                                wait,voldmanaged=sdcard1:auto,noemulatedsd
+/devices/platform/msm_sdcc.1/mmc_host/mmc1       auto vfat defaults                                wait,voldmanaged=sdcard1:auto
 /devices/platform/msm_hsusb_host                 auto auto defaults                                     voldmanaged=usbdisk:auto
 
 /dev/block/zram0                         none               swap    defaults                                zramsize=201326592


### PR DESCRIPTION
This reverts commit 66aaa6a290955bfeee63f0d8faeb2f553200a45c.
